### PR TITLE
BUGFIX/MINOR(conscience): Remove unnecessary semicolon in pools and change wording of pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,22 @@ An Ansible role for conscience. Specifically, the responsibilities of this role 
 
 | Variable   | Default | Comments (type)  |
 | :---       | :---    | :---             |
-| `openio_conscience_bind_interface` | `"{{ ansible_default_ipv4.alias }}"` | ... |
-| `openio_conscience_bind_address` | `"{{ hostvars[inventory_hostname]['ansible_' + openio_conscience_bind_interface]['ipv4']['address'] }}"` | ... |
-| `openio_conscience_bind_port` | `6000` | ... |
+| `openio_conscience_bind_interface` | `"{{ ansible_default_ipv4.alias }}"` | Interface to use. |
+| `openio_conscience_bind_address` | `"{{ hostvars[inventory_hostname]['ansible_' + openio_conscience_bind_interface]['ipv4']['address'] }}"` | Address IP to use |
+| `openio_conscience_bind_port` | `6000` | Listening port |
 | `openio_conscience_gridinit_dir` | `/etc/gridinit.d/{{ openio_conscience_namespace }}` | Path to copy the gridinit conf |
 | `openio_conscience_gridinit_file_prefix` | `""` | Maybe set it to {{ openio_conscience_namespace }}- for old gridinit's style |
-| `openio_conscience_data_security_custom` | `{}` | ... |
-| `openio_conscience_multiple` | `{}` | ... |
-| `openio_conscience_namespace` | `"OPENIO"` | ... |
-| `openio_conscience_plugins` | `` | ... |
-| `openio_conscience_pools` | `[]` | ... |
-| `openio_conscience_server` | `` | ... |
-| `openio_conscience_serviceid` | `"0"` | ... |
-| `openio_conscience_services` | `` | ... |
-| `openio_conscience_storage_policies_custom` | `{}` | ... |
-| `openio_conscience_timeout_accepting_connection` | `1000` | ... |
-| `openio_conscience_timeout_read_operations` | `1000` | ... |
+| `openio_conscience_data_security_custom` | `{}` | Dict of customized data security |
+| `openio_conscience_multiple` | `{}` |  Dict of multiple consciences |
+| `openio_conscience_namespace` | `"OPENIO"` | Namespace |
+| `openio_conscience_plugins` | `` | Conscience plugins |
+| `openio_conscience_pools` | `[]` | Conscience pools |
+| `openio_conscience_server` | `` | Conscience configuration |
+| `openio_conscience_serviceid` | `"0"` | ID in gridinit |
+| `openio_conscience_services` | `` | Dict of OpenIO services and its score formula |
+| `openio_conscience_storage_policies_custom` | `{}` | Dict of customized storage policies |
+| `openio_conscience_timeout_accepting_connection` | `1000` | Timeout for accepting connection |
+| `openio_conscience_timeout_read_operations` | `1000` | Timeout for read connection |
 | `openio_conscience_version` | `latest` | Install a specific version |
 | `openio_conscience_provision_only` | `false` | Provision only, without restarting the services |
 
@@ -64,11 +64,11 @@ No dependencies.
       openio_conscience_pools:
         - name: rawx21
           targets:
-            - where: rawx-europe
-              type: rawx
+            - slot: rawx-europe
+              fallback: rawx
               count: 2
-            - where: rawx-asia
-              type: rawx
+            - slot: rawx-asia
+              fallback: rawx
               count: 1
           min_dist: 2
 

--- a/templates/services.conf.j2
+++ b/templates/services.conf.j2
@@ -29,10 +29,10 @@
 # "warn_dist" is the distance between services at which the pool will emit
 # a warning, for further improvement.
 
+
 {% for pool in openio_conscience_pools %}
 [pool:{{ pool.name }}]
-{% set targets = openio_conscience_pools | map(attribute='targets') | list | first %}
-targets={% for target in targets %}{{target.count}},{{target.where}},{{target.type}};{% endfor %}
+targets={% for target in pool.targets %}{{target.count}},{{target.slot}},{{target.fallback}}{% if not loop.last %};{% endif %}{% endfor %}
 
 {% for key, value in pool.iteritems() %}
 {% if key != 'name' and key != 'targets' %}


### PR DESCRIPTION
 ##### ISSUE TYPE
- Bugfix

 ##### SUMMARY
Currently, pools generated are like:
```
[pool:rawx3]
targets=1,rawx-site1,rawx;1,rawx-site2,rawx;1,rawx-site3,rawx;
min_dist=2
warn_dist=2
```
The last semicolon is too much

 ##### SCOPE (skeleton only)
- conscience

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION

* The wording is not relevant in the pool dict. Pools are not used today, so it's worth to change it now.
* Add description in README.