### PR TITLE
BUGFIX(conscience): Fix multiple conscience deployment

### DIFF
--- a/templates/conscience.conf.j2
+++ b/templates/conscience.conf.j2
@@ -33,12 +33,12 @@ load_ns_info=false
 {{ key }}={{ value }}
 {% endif %}
 {% endfor %}
-# end plugin {{ plugin.name }}
+{% if openio_conscience_multiple and plugin.name == "conscience" %}
 
-{% endfor %}
-
-{% if openio_conscience_multiple %}
 # Multi-conscience
 param_hub.me=tcp://{{ openio_conscience_multiple.me }}
 param_hub.group={{ openio_conscience_multiple.group | map('regex_replace', '(.*)', 'tcp://\\1') | list | join(',') }}
 {% endif %}
+# end plugin {{ plugin.name }}
+
+{% endfor %}


### PR DESCRIPTION
 ##### SUMMARY
Multiple conscience deployment was broken as the configuration
directives were not put at the right place. They were put at the end of
the file whereas they should have be placed in the `[Plugin.conscience]`
section.

 ##### ISSUE TYPE
- Bugfix Pull Request

 ##### SCOPE (skeleton only)
- SDS

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION