### PR TITLE
FEATURE(conscience): Add scoring of beanstalkd and oioproxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ openio_conscience_provision_only: false
 
 openio_conscience_bind_interface: "{{ ansible_default_ipv4.alias }}"
 openio_conscience_bind_address: "{{ openio_bind_address \
-  | default(hostvars[inventory_hostname]['ansible_' + openio_conscience_bind_interface]['ipv4']['address']) }}" 
+  | default(hostvars[inventory_hostname]['ansible_' + openio_conscience_bind_interface]['ipv4']['address']) }}"
 openio_conscience_bind_port: 6000
 openio_conscience_gridinit_dir: "/etc/gridinit.d/{{ openio_conscience_namespace }}"
 openio_conscience_gridinit_file_prefix: ""
@@ -71,4 +71,12 @@ openio_conscience_services:
   account:
     score_expr: "(num tag.up) * ((num stat.cpu)+1)"
     score_timeout: 120
+  beanstalkd:
+    score_expr: "root(3, (num stat.cpu) * (num stat.space) * (100 - root(3, (num stat.jobs_ready))))"
+    score_timeout: 120
+    score_lock_at_first_register: false
+  oioproxy:
+    score_expr: "(num stat.cpu)"
+    score_timeout: 120
+    score_lock_at_first_register: false
 ...

--- a/docker-tests/requirements.yml
+++ b/docker-tests/requirements.yml
@@ -1,29 +1,29 @@
 ---
 - src: https://github.com/open-io/ansible-role-openio-repository.git
-  version: master
+  version: "19.04"
   name: repository
 
 - src: https://github.com/open-io/ansible-role-openio-gridinit.git
-  version: master
+  version: "19.04"
   name: gridinit
 
 - src: https://github.com/open-io/ansible-role-openio-namespace.git
-  version: master
+  version: "19.04"
   name: namespace
 
 - src: https://github.com/open-io/ansible-role-openio-users.git
-  version: master
+  version: "19.04"
   name: users
 
 - src: https://github.com/open-io/ansible-role-openio-meta.git
-  version: master
+  version: "19.04"
   name: meta
 
 - src: https://github.com/open-io/ansible-role-openio-conscienceagent.git
-  version: master
+  version: "19.04"
   name: conscienceagent
 
 - src: https://github.com/open-io/ansible-role-openio-oioproxy.git
-  version: master
+  version: "19.04"
   name: oioproxy
 ...

--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -5,11 +5,7 @@
     NS: TRAVIS
   roles:
     - role: repository
-      openio_repository_openstack_release: 'queens'
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
     - role: users
     - role: namespace
       openio_namespace_name: "{{ NS }}"


### PR DESCRIPTION
 ##### SUMMARY

In this release, `beanstalkd` and `oioproxy` can be scored by the conscience

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```console
conf@ba6d293d63be:/# cat /etc/oio/sds/TRAVIS/conscience-0/conscience-0-services.c

[pool:rawx21]
targets=2,rawx-europe,rawx;1,rawx-asia,rawx
min_dist=2

[type:sqlx]
score_expr=((num stat.space)>=5) * root(3,(((num stat.cpu)+1)*(num stat.space)*((num stat.io)+1)))
score_timeout=120

[type:account]
score_expr=(num tag.up) * ((num stat.cpu)+1)
score_timeout=120

[type:rawx]
score_expr=(num tag.up) * ((num stat.space)>=5) * root(3,(((num stat.cpu)+1)*(num stat.space)*((num stat.io)+1)))
score_timeout=120

[type:rdir]
score_expr=(num tag.up) * ((num stat.cpu)+1) * ((num stat.space)>=2)
score_timeout=120

[type:redis]
score_expr=(num tag.up) * ((num stat.cpu)+1)
score_timeout=120

[type:oioproxy]
score_expr=(num stat.cpu)
score_timeout=120
lock_at_first_register=False

[type:meta0]
score_expr=root(2,((num stat.cpu) * ((num stat.io)+1)))
score_timeout=3600

[type:meta1]
score_expr=((num stat.space)>=5) * root(3,(((num stat.cpu)+1)*(num stat.space)*((num stat.io)+1)))
score_timeout=120

[type:meta2]
score_expr=((num stat.space)>=5) * root(3,(((num stat.cpu)+1)*(num stat.space)*((num stat.io)+1)))
score_timeout=120

[type:beanstalkd]
score_expr=(num stat.cpu)
score_timeout=120
lock_at_first_register=False
```