### PR TITLE
FEATURE(conscience): Allow persistence of data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ An Ansible role for conscience. Specifically, the responsibilities of this role 
 | `openio_conscience_data_security_custom` | `{}` | Dict of customized data security |
 | `openio_conscience_multiple` | `{}` |  Dict of multiple consciences |
 | `openio_conscience_namespace` | `"OPENIO"` | Namespace |
+| `openio_conscience_persistence_period` | `30` | Time in second for score persistence |
 | `openio_conscience_plugins` | `` | Conscience plugins |
 | `openio_conscience_pools` | `[]` | Conscience pools |
 | `openio_conscience_server` | `` | Conscience configuration |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,4 +79,6 @@ openio_conscience_services:
     score_expr: "(num stat.cpu)"
     score_timeout: 120
     score_lock_at_first_register: false
+
+openio_conscience_persistence_period: 30
 ...

--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -6,6 +6,7 @@
   roles:
     - role: repository
       openio_repository_no_log: false
+      openio_repository_mirror_host: mirror2.openio.io
     - role: users
     - role: namespace
       openio_namespace_name: "{{ NS }}"

--- a/templates/gridinit_conscience.conf.j2
+++ b/templates/gridinit_conscience.conf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 [Service.{{ openio_conscience_namespace }}-{{ openio_conscience_servicename }}]
-command=/usr/bin/oio-daemon -s OIO,{{ openio_conscience_namespace }},conscience,{{ openio_conscience_serviceid }} /etc/oio/sds/{{ openio_conscience_namespace }}/{{ openio_conscience_servicename }}/{{ openio_conscience_servicename }}.conf
+command=/usr/bin/oio-daemon -s OIO,{{ openio_conscience_namespace }},conscience,{{ openio_conscience_serviceid }} /etc/oio/sds/{{ openio_conscience_namespace }}/{{ openio_conscience_servicename }}/{{ openio_conscience_servicename }}.conf -O PersistencePath={{ openio_conscience_persistence_file }} -O PersistencePeriod={{ openio_conscience_persistence_period }}
 enabled=true
 start_at_boot=true
 on_die=respawn

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -35,4 +35,6 @@ openio_conscience_storage_policies_definition_file: "{{ openio_conscience_syscon
   conscience-{{ openio_conscience_serviceid }}/conscience-{{ openio_conscience_serviceid }}-policies.conf"
 openio_conscience_services_file: "{{ openio_conscience_sysconfig_dir }}/\
   conscience-{{ openio_conscience_serviceid }}/conscience-{{ openio_conscience_serviceid }}-services.conf"
+openio_conscience_persistence_file: "{{ openio_conscience_sysconfig_dir }}/\
+  conscience-{{ openio_conscience_serviceid }}/conscience-{{ openio_conscience_serviceid }}-persistence.dat"
 ...


### PR DESCRIPTION
OB-363

 ##### SUMMARY

We need to make sure conscience deployments persist the scores, to allow for a better fallback (without resetting them)

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```console
root@bd1628ad1c80:/# gridinit_cmd status2 @conscience -c
KEY                 STATUS     PID #START #DIED               SINCE               GROUP CMD
TRAVIS-conscience-0 UP        6547      2     0 2019-05-02 13:54:50 TRAVIS,conscience,0 /usr/bin/oio-daemon -s OIO,TRAVIS,conscience,0 /etc/oio/sds/TRAVIS/conscience-0/conscience-0.conf -O PersistencePath=/etc/oio/sds/TRAVIS/conscience-0/conscience-0-persistence.dat -O PersistencePeriod=30
```