### PR TITLE
CHANGE(conscience): Ensure service is started or restarted at the end of role

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -3,6 +3,7 @@
   become: true
   vars:
     NS: TRAVIS
+    openio_bootstrap: true
   roles:
     - role: repository
       openio_repository_no_log: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,13 +51,35 @@
         {{ openio_conscience_servicename }}.conf"
   register: _conscience_conf
 
-- name: restart conscience
+- name: "restart conscience to apply the new configuration"
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart {{ openio_conscience_namespace }}-{{ openio_conscience_servicename }}
+  register: _restart_conscience
   when:
-    - _conscience_conf.changed
+    - _conscience_conf is changed
     - not openio_conscience_provision_only
   tags: configure
 
+- block:
+    - name: "Ensure conscience is started"
+      command: gridinit_cmd start {{ openio_conscience_namespace }}-{{ openio_conscience_servicename }}
+      register: _start_conscience
+      changed_when: '"Success" in _start_conscience.stdout'
+      when:
+        - not openio_conscience_provision_only
+        - _restart_conscience is skipped
+      tags: configure
+
+    - name: check conscience
+      command: "oio-tool ping {{ openio_conscience_bind_address }}:{{ openio_conscience_bind_port }}"
+      register: _conscience_check
+      retries: 3
+      delay: 5
+      until: _conscience_check is success
+      changed_when: false
+      failed_when:
+        - _conscience_check.rc != 0
+        - "'PING OK' not in _conscience_check.stdout"
+  when: openio_bootstrap | d(false)
 ...


### PR DESCRIPTION
#### SUMMARY

Until 18.10, a voluntarily stopped service was not revived by a reproviosionning.

In 19.04, the `maintenance` mode becomes the default mode.

To avoid having to force (ie. deletion of conf files) the restart of a service delivered first, by error, in maintenance mode: We have to make sure that service is started and it works well at the end of the role.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION