### PR TITLE
CHANGE(conscience): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ An Ansible role for conscience. Specifically, the responsibilities of this role 
 | `openio_conscience_timeout_read_operations` | `1000` | Timeout for read connection |
 | `openio_conscience_version` | `latest` | Install a specific version |
 | `openio_conscience_provision_only` | `false` | Provision only, without restarting the services |
+| `openio_conscience_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ openio_conscience_serviceid: "{{ 0 + openio_legacy_serviceid | d(0) | int }}"
 openio_conscience_version: 'latest'
 
 openio_conscience_provision_only: false
+openio_conscience_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 
 openio_conscience_inventory_groupname: "conscience"
 

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_conscience_package_upgrade else 'present' }}"
   with_items: "{{ conscience_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_conscience_package_upgrade else 'present' }}"
   with_items: "{{ conscience_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION