### PR TITLE
BUGFIX/MINOR(conscience): Add compat with python3

### DIFF
--- a/templates/conscience.conf.j2
+++ b/templates/conscience.conf.j2
@@ -28,7 +28,7 @@ load_ns_info=false
 
 {% for plugin in openio_conscience_plugins %}
 [Plugin.{{ plugin.name }}]
-{% for key, value in plugin.iteritems() %}
+{% for key, value in plugin.items() | list %}
 {% if key != 'name' %}
 {{ key }}={{ value }}
 {% endif %}

--- a/templates/policies.conf.j2
+++ b/templates/policies.conf.j2
@@ -6,7 +6,7 @@
 # The first word is the service pool to use,
 # the second word is the data security to use.
 {% set storage = storage_policies | combine(openio_conscience_storage_policies_custom) %}
-{% for policyname, policy in storage.iteritems() %}
+{% for policyname, policy in storage.items() | list %}
 {{ policyname }}={{ policy }}
 {% endfor %}
 
@@ -24,6 +24,6 @@
 # "shss"                   EC_BACKEND_SHSS
 # "liberasurecode_rs_vand" EC_BACKEND_LIBERASURECODE_RS_VAND
 {% set data = data_security | combine(openio_conscience_data_security_custom) %}
-{% for securityname, security in data.iteritems() %}
+{% for securityname, security in data.items() | list %}
 {{ securityname }}={{ security }}
 {% endfor %}

--- a/templates/services.conf.j2
+++ b/templates/services.conf.j2
@@ -34,7 +34,7 @@
 [pool:{{ pool.name }}]
 targets={% for target in pool.targets %}{{target.count}},{{target.slot}},{{target.fallback}}{% if not loop.last %};{% endif %}{% endfor %}
 
-{% for key, value in pool.iteritems() %}
+{% for key, value in pool.items() | list %}
 {% if key != 'name' and key != 'targets' %}
 {{ key }}={{ value }}
 {% endif %}
@@ -45,7 +45,7 @@ targets={% for target in pool.targets %}{{target.count}},{{target.slot}},{{targe
 # Service types declarations
 # ---------------------------
 
-{% for service, values in openio_conscience_services.iteritems()%}
+{% for service, values in openio_conscience_services.items() | list %}
 [type:{{service}}]
 score_expr={{values.score_expr}}
 score_timeout={{values.score_timeout}}


### PR DESCRIPTION
 ##### SUMMARY

Replace python 2 syntax by one compatible with python 2 and 3.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
failed: [node07] (item={'src': 'services.conf.j2', 'dest': '/etc/oio/sds/OPENIO/conscience-0/conscience-0-services.conf'}) => changed=false
  ansible_loop_var: item
  item:
    dest: /etc/oio/sds/OPENIO/conscience-0/conscience-0-services.conf
    src: services.conf.j2
  msg: 'AnsibleUndefinedVariable: ''dict object'' has no attribute ''iteritems'''
```
https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#dict-iteritems