### PR TITLE
CHANGE(conscience): Use the persistence file with multi-conscience

### DIFF
--- a/templates/gridinit_conscience.conf.j2
+++ b/templates/gridinit_conscience.conf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 [Service.{{ openio_conscience_namespace }}-{{ openio_conscience_servicename }}]
-command=/usr/bin/oio-daemon -s OIO,{{ openio_conscience_namespace }},conscience,{{ openio_conscience_serviceid }} /etc/oio/sds/{{ openio_conscience_namespace }}/{{ openio_conscience_servicename }}/{{ openio_conscience_servicename }}.conf {% if not openio_conscience_multiple_enable %}-O PersistencePath={{ openio_conscience_persistence_file }} {% endif %}-O PersistencePeriod={{ openio_conscience_persistence_period }}
+command=/usr/bin/oio-daemon -s OIO,{{ openio_conscience_namespace }},conscience,{{ openio_conscience_serviceid }} /etc/oio/sds/{{ openio_conscience_namespace }}/{{ openio_conscience_servicename }}/{{ openio_conscience_servicename }}.conf -O PersistencePath={{ openio_conscience_persistence_file }} -O PersistencePeriod={{ openio_conscience_persistence_period }}
 enabled=true
 start_at_boot=true
 on_die=respawn


### PR DESCRIPTION
##### SUMMARY

Currently, the persistence file is automatically ignored when multi-conscience is enabled.
It is therefore not necessary not to pass the persistence file as an option.

Soon, the multi-conscience will be able to use the persistence file. (https://github.com/open-io/oio-sds/pull/2093)

##### IMPACT

N/A

##### ADDITIONAL INFORMATION